### PR TITLE
Fix broken headers and options

### DIFF
--- a/src/lhttpc_otel.hrl
+++ b/src/lhttpc_otel.hrl
@@ -27,9 +27,9 @@
 
 -define(OTEL_SETATTRS(Attrs), begin _ = Attrs, ok end).
 
--define(OTEL_HEADERS(), ok).
+-define(OTEL_HEADERS(), []).
 
--define(OTEL_OPTIONS(), ok).
+-define(OTEL_OPTIONS(), []).
 
 -define(OTEL_END(Status), begin _ = Status, ok end).
 


### PR DESCRIPTION
In case without `open_telemetry` options and headers become `ok` atom instead of list. It leads to badmatch and broken request functionality.